### PR TITLE
Add persona YAML and Jinja prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Make sure LM Studio is running at `http://localhost:1234` with a supported model
 - `persona_model.py`: Pydantic schema
 - `utils.py`: Prompt builder
 - `memory_manager.py`: JSON storage
+- `data/personas/default.yaml`: Example persona loaded for system prompts

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -5,11 +5,13 @@ from utils import build_system_prompt
 client = OpenAI(base_url="http://localhost:1234/v1", api_key="lm-studio")
 
 
-def chat_with_ai(persona, history, user_input):
-    messages = [{
-        "role": "system",
-        "content": build_system_prompt(persona),
-    }]
+def chat_with_ai(persona_file, history, user_input):
+    messages = [
+        {
+            "role": "system",
+            "content": build_system_prompt(persona_file),
+        }
+    ]
     for entry in history:
         messages.append({"role": "user", "content": entry["user"]})
         messages.append({"role": "assistant", "content": entry["ai"]})

--- a/data/personas/default.yaml
+++ b/data/personas/default.yaml
@@ -1,0 +1,13 @@
+name: Aiden the Mentor
+backstory: |
+  Aiden is a centuries-old wizard who has guided heroes through their quests.
+  He speaks with calm authority and a hint of humor.
+tone: Wise and encouraging
+objectives:
+  - Provide thoughtful advice
+  - Encourage personal growth
+  - Share ancient knowledge
+sample_dialogues:
+  - "Every challenge hides a lesson, if you listen carefully."
+  - "Patience is a virtue even the bravest must learn."
+  - "Remember, your greatest power lies within your curiosity."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 streamlit
 openai
 pydantic
+jinja2
+pyyaml

--- a/utils.py
+++ b/utils.py
@@ -1,16 +1,36 @@
 
 
-def build_system_prompt(persona):
-    return (
-        f"""
-You are {persona.name}, a {persona.age}-year-old {persona.species}.
-Traits:
-- Personality: {persona.personality}
-- Tone: {persona.tone}
-- Quirks: {persona.quirks}
-- Communication Style: {persona.communication_style}
-- Emotional Depth: {persona.emotional_depth}
+import json
+import yaml
+from jinja2 import Template
 
-Speak naturally and stay in character at all times.
+
+def load_persona(file_path):
+    """Load persona data from a YAML or JSON file."""
+    with open(file_path, "r") as f:
+        if file_path.endswith(".json"):
+            return json.load(f)
+        return yaml.safe_load(f)
+
+
+SYSTEM_TEMPLATE = Template(
+    """
+You are {{ name }}.
+Backstory: {{ backstory }}
+Tone: {{ tone }}
+Objectives:
+{% for obj in objectives %}- {{ obj }}
+{% endfor %}
+Sample Dialogues:
+{% for line in sample_dialogues %}- {{ line }}
+{% endfor %}
+
+Stay in character and respond accordingly.
 """
-    )
+)
+
+
+def build_system_prompt(file_path):
+    """Build a system prompt from a persona file using Jinja."""
+    data = load_persona(file_path)
+    return SYSTEM_TEMPLATE.render(**data)


### PR DESCRIPTION
## Summary
- provide a sample persona YAML document
- load persona via Jinja in `build_system_prompt`
- update chat engine to use persona file
- document example persona in README
- add `jinja2` and `pyyaml` requirements

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684e783db118832f98f8db0719333103