### PR TITLE
Integrate character editor in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A fully local roleplay app powered by LM Studio. Define a character and chat with them using local LLMs.
 
-## 🧰 Features
-- Persona builder with sliders and text fields
+- Persona builder with sliders and text fields (accessible from the sidebar)
 - Streamlit-based chat UI
 - Local LLM connection via LM Studio (OpenAI-compatible API)
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from openai import OpenAI
+from character_interface import show_character_editor
 import json
 import os
 
@@ -58,6 +59,10 @@ if st.sidebar.button("📂 Load Chat") and os.path.exists("chat_history.json"):
 if st.sidebar.button("🗑️ Clear Chat"):
     st.session_state["messages"] = []
     st.rerun()
+
+# Character Editor in sidebar
+with st.sidebar.expander("📝 Character Editor"):
+    show_character_editor()
 
 # --- Session State Init ---
 st.session_state.setdefault("messages", [])


### PR DESCRIPTION
## Summary
- expose `show_character_editor` from `character_interface` in the sidebar
- clarify in README that the persona builder lives in the sidebar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e7c859d84832f9e0b2bac05e746bf