### PR TITLE
Refactor to multipage app with st.navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A fully local roleplay app powered by LM Studio. Define a character and chat with them using local LLMs.
 
-- Persona builder with sliders and text fields (accessible from the sidebar)
+- Persona builder with sliders and text fields (via the navigation menu)
 - Streamlit-based chat UI
 - Local LLM connection via LM Studio (OpenAI-compatible API)
+- Multipage navigation with `st.navigation`
 
 ## 🚀 How to Run
 

--- a/main.py
+++ b/main.py
@@ -4,126 +4,128 @@ from character_interface import show_character_editor
 import json
 import os
 
-# --- Initialize OpenAI client for LM Studio ---
+# Initialize OpenAI client for LM Studio
 client = OpenAI(base_url="http://localhost:1234/v1", api_key="lm-studio")
 
-# --- Streamlit App Config ---
-st.set_page_config(page_title="Local ChatGPT Clone")
-st.title("🧠 Local ChatGPT Clone (LM Studio)")
 
-# --- Sidebar Controls ---
-st.sidebar.header("⚙️ Settings")
+def landing_page():
+    """Simple landing page."""
+    st.title("AI Character Roleplay Engine")
+    st.write(
+        "Use the navigation menu to start chatting with your persona or edit their traits."
+    )
 
-# Load available models from LM Studio
-try:
-    models = client.models.list()
-    available_models = [m.id for m in models.data]
-except Exception:
-    available_models = ["gpt-3.5-turbo"]
-    st.sidebar.warning("Could not fetch models dynamically. Using fallback.")
 
-model_id = st.sidebar.selectbox(
-    "Choose your model",
-    available_models,
-    index=0,
-)
-st.session_state.setdefault("openai_model", model_id)
+def chat_page():
+    """Main chat interface."""
+    st.title("\U0001F9E0 Local ChatGPT Clone (LM Studio)")
 
-# Generation Parameters
-temperature = st.sidebar.slider("🎛 Temperature", 0.0, 1.5, 0.7, 0.1)
-top_p = st.sidebar.slider("🧠 Top-p", 0.0, 1.0, 1.0, 0.05)
-max_tokens = st.sidebar.slider("📏 Max Tokens", 64, 2048, 512, 64)
+    st.sidebar.header("\u2699\ufe0f Settings")
 
-# Personality Presets
-persona = st.sidebar.selectbox(
-    "🤖 Personality",
-    ["Default", "Sassy", "Wise Mentor"],
-)
-prompts = {
-    "Default": "You are a helpful assistant.",
-    "Sassy": "You're witty, sarcastic, and have a sharp tongue.",
-    "Wise Mentor": "You are wise and calm, guiding the user with experience."
-}
-system_prompt = prompts[persona]
+    # Load available models from LM Studio
+    try:
+        models = client.models.list()
+        available_models = [m.id for m in models.data]
+    except Exception:
+        available_models = ["gpt-3.5-turbo"]
+        st.sidebar.warning("Could not fetch models dynamically. Using fallback.")
 
-# Save/Load Chat
-if st.sidebar.button("💾 Save Chat"):
-    with open("chat_history.json", "w") as f:
-        json.dump(st.session_state.get("messages", []), f)
+    model_id = st.sidebar.selectbox(
+        "Choose your model", available_models, index=0
+    )
+    st.session_state.setdefault("openai_model", model_id)
 
-if st.sidebar.button("📂 Load Chat") and os.path.exists("chat_history.json"):
-    with open("chat_history.json", "r") as f:
-        st.session_state["messages"] = json.load(f)
+    temperature = st.sidebar.slider("\U0001F39B Temperature", 0.0, 1.5, 0.7, 0.1)
+    top_p = st.sidebar.slider("\U0001F9E0 Top-p", 0.0, 1.0, 1.0, 0.05)
+    max_tokens = st.sidebar.slider("\U0001F4CF Max Tokens", 64, 2048, 512, 64)
+
+    persona = st.sidebar.selectbox(
+        "\U0001F916 Personality", ["Default", "Sassy", "Wise Mentor"]
+    )
+    prompts = {
+        "Default": "You are a helpful assistant.",
+        "Sassy": "You're witty, sarcastic, and have a sharp tongue.",
+        "Wise Mentor": "You are wise and calm, guiding the user with experience.",
+    }
+    system_prompt = prompts[persona]
+
+    if st.sidebar.button("\U0001F4BE Save Chat"):
+        with open("chat_history.json", "w") as f:
+            json.dump(st.session_state.get("messages", []), f)
+
+    if st.sidebar.button("\U0001F4C2 Load Chat") and os.path.exists("chat_history.json"):
+        with open("chat_history.json", "r") as f:
+            st.session_state["messages"] = json.load(f)
+            st.rerun()
+
+    if st.sidebar.button("\U0001F5D1\ufe0f Clear Chat"):
+        st.session_state["messages"] = []
         st.rerun()
 
-if st.sidebar.button("🗑️ Clear Chat"):
-    st.session_state["messages"] = []
-    st.rerun()
+    st.session_state.setdefault("messages", [])
 
-# Character Editor in sidebar
-with st.sidebar.expander("📝 Character Editor"):
+    if not any(m["role"] == "system" for m in st.session_state["messages"]):
+        st.session_state["messages"].insert(0, {"role": "system", "content": system_prompt})
+
+    for msg in st.session_state["messages"]:
+        with st.chat_message(msg["role"]):
+            st.markdown(msg["content"])
+
+    if prompt := st.chat_input("What would you like to ask?"):
+        st.chat_message("user").markdown(prompt)
+        st.session_state["messages"].append({"role": "user", "content": prompt})
+
+        with st.chat_message("assistant"):
+            response_box = st.empty()
+            full_response = ""
+            try:
+                stream = client.chat.completions.create(
+                    model=model_id,
+                    messages=st.session_state["messages"],
+                    temperature=temperature,
+                    top_p=top_p,
+                    max_tokens=max_tokens,
+                    stream=True,
+                )
+                for chunk in stream:
+                    delta = chunk.choices[0].delta
+                    content = getattr(delta, "content", None)
+                    if content is not None:
+                        full_response += content
+                        response_box.markdown(full_response)
+            except Exception as e:
+                st.error(f"Error during model response: {e}")
+                full_response = "\u26a0\ufe0f Error occurred while generating response."
+
+        st.session_state["messages"].append({"role": "assistant", "content": full_response})
+        st.markdown(
+            "<script>window.scrollTo(0,document.body.scrollHeight);</script>",
+            unsafe_allow_html=True,
+        )
+
+    def estimate_tokens(messages):
+        return sum(len(msg["content"].split()) for msg in messages) * 1.3
+
+    st.sidebar.markdown(
+        f"\U0001F9EE Estimated Tokens: `{int(estimate_tokens(st.session_state['messages']))}`"
+    )
+
+
+def edit_page():
+    """Page for editing character traits."""
+    st.title("\U0001F4DD Persona Builder")
     show_character_editor()
 
-# --- Session State Init ---
-st.session_state.setdefault("messages", [])
 
-# Insert system prompt if not already present
-if not any(m["role"] == "system" for m in st.session_state["messages"]):
-    st.session_state["messages"].insert(
-        0,
-        {"role": "system", "content": system_prompt},
-    )
+# Configure page and register navigation
+st.set_page_config(page_title="AI Character Roleplay", page_icon="\U0001F916")
 
-# --- Chat History Display ---
-for msg in st.session_state["messages"]:
-    with st.chat_message(msg["role"]):
-        st.markdown(msg["content"])
-
-# --- User Input ---
-if prompt := st.chat_input("What would you like to ask?"):
-    st.chat_message("user").markdown(prompt)
-    st.session_state["messages"].append({"role": "user", "content": prompt})
-
-    with st.chat_message("assistant"):
-        response_box = st.empty()
-        full_response = ""
-        try:
-            stream = client.chat.completions.create(
-                model=model_id,
-                messages=st.session_state["messages"],
-                temperature=temperature,
-                top_p=top_p,
-                max_tokens=max_tokens,
-                stream=True,
-            )
-            for chunk in stream:
-                delta = chunk.choices[0].delta
-                content = getattr(delta, "content", None)
-                if content is not None:
-                    full_response += content
-                    response_box.markdown(full_response)
-        except Exception as e:
-            st.error(f"Error during model response: {e}")
-            full_response = "⚠️ Error occurred while generating response."
-
-    st.session_state["messages"].append(
-        {"role": "assistant", "content": full_response},
-    )
-
-    # Auto-scroll to bottom (visual aid)
-    st.markdown(
-        "<script>window.scrollTo(0,document.body.scrollHeight);</script>",
-        unsafe_allow_html=True,
-    )
-
-# --- Token Estimate ---
-
-
-def estimate_tokens(messages):
-    return sum(len(msg["content"].split()) for msg in messages) * 1.3
-
-
-st.sidebar.markdown(
-    f"🧮 Estimated Tokens: `"
-    f"{int(estimate_tokens(st.session_state['messages']))}`"
+pg = st.navigation(
+    [
+        st.Page(landing_page, title="Home", icon="\U0001F3E0", default=True),
+        st.Page(chat_page, title="Chat", icon="\U0001F4AC"),
+        st.Page(edit_page, title="Persona Builder", icon="\U0001F4DD"),
+    ]
 )
+
+pg.run()


### PR DESCRIPTION
## Summary
- refactor `main.py` into a multipage Streamlit app using `st.navigation`
- provide dedicated `chat_page`, `edit_page`, and landing page callables
- update README to mention multipage navigation

## Testing
- `pytest -q`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684e7f6166d4832fa6d0f1d526976634