### PR TITLE
Add psychological profile fields to personas

### DIFF
--- a/character_interface.py
+++ b/character_interface.py
@@ -24,6 +24,35 @@ def show_character_editor():
         "Stay positive and support the user at all times.",
     )
 
+    st.subheader("Psychological Profile")
+    emotional_sensitivity = st.select_slider(
+        "Emotional Sensitivity",
+        options=["Very Low", "Low", "Medium", "High", "Very High"],
+        value="Medium",
+    )
+    confidence_level = st.select_slider(
+        "Confidence Level",
+        options=["Insecure", "Low", "Medium", "High", "Confident"],
+        value="Medium",
+    )
+    curiosity_level = st.select_slider(
+        "Curiosity Level",
+        options=["Uninterested", "Low", "Medium", "High", "Inquisitive"],
+        value="Medium",
+    )
+    moral_compass = st.selectbox(
+        "Moral Compass",
+        ["Utilitarian", "Deontological", "Situational", "Chaotic Good", "Neutral"],
+    )
+    conflict_style = st.selectbox(
+        "Conflict Resolution Style",
+        ["Avoidant", "Assertive", "Aggressive", "Passive-Aggressive"],
+    )
+    attachment_style = st.selectbox(
+        "Attachment Style",
+        ["Secure", "Anxious", "Avoidant", "Disorganized"],
+    )
+
     if st.button("Save Persona"):
         persona = Persona(
             who=who,
@@ -31,6 +60,12 @@ def show_character_editor():
             why=why,
             relationship=relationship,
             rules=rules,
+            emotional_sensitivity=emotional_sensitivity,
+            confidence_level=confidence_level,
+            curiosity_level=curiosity_level,
+            moral_compass=moral_compass,
+            conflict_style=conflict_style,
+            attachment_style=attachment_style,
         )
         os.makedirs("data/saved_personas", exist_ok=True)
         filename = f"{who.replace(' ', '_').lower()}.json"

--- a/data/personas/default.yaml
+++ b/data/personas/default.yaml
@@ -6,3 +6,9 @@ rules: |
   - Stay positive and supportive
   - Offer guidance when asked
   - Remain consistent with the mentor persona
+emotional_sensitivity: Medium
+confidence_level: High
+curiosity_level: High
+moral_compass: Utilitarian
+conflict_style: Assertive
+attachment_style: Secure

--- a/persona_model.py
+++ b/persona_model.py
@@ -1,5 +1,6 @@
 """Pydantic schema for persona files."""
 
+from typing import Optional
 from pydantic import BaseModel
 
 
@@ -11,4 +12,10 @@ class Persona(BaseModel):
     why: str
     relationship: str
     rules: str
+    emotional_sensitivity: Optional[str] = None
+    confidence_level: Optional[str] = None
+    curiosity_level: Optional[str] = None
+    moral_compass: Optional[str] = None
+    conflict_style: Optional[str] = None
+    attachment_style: Optional[str] = None
 

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,12 @@ You are {{ who }}.
 Relationship to user: {{ relationship }}
 Speak in this style: {{ how }}
 Your purpose: {{ why }}
+Emotional Sensitivity: {{ emotional_sensitivity | default('') }}
+Confidence Level: {{ confidence_level | default('') }}
+Curiosity Level: {{ curiosity_level | default('') }}
+Moral Compass: {{ moral_compass | default('') }}
+Conflict Style: {{ conflict_style | default('') }}
+Attachment Style: {{ attachment_style | default('') }}
 Rules:\n{{ rules }}
 
 Stay in character and respond accordingly.


### PR DESCRIPTION
## Summary
- extend `Persona` model with optional psychological profile attributes
- collect profile data in persona builder UI
- insert new fields into system prompt template
- update default persona with example values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e9a784814832f9e9a327bd1344763