### PR TITLE
Add persona chat history storage

### DIFF
--- a/memory_manager.py
+++ b/memory_manager.py
@@ -12,3 +12,21 @@ def load_memory(filename):
 def save_memory(filename, data):
     with open(filename, "w") as f:
         json.dump(data, f, indent=2)
+
+
+def history_path(persona_label: str) -> str:
+    """Return the storage path for a persona's conversation history."""
+    os.makedirs("data/chat_history", exist_ok=True)
+    base = os.path.splitext(persona_label)[0]
+    base = base.replace(" ", "_").lower()
+    return os.path.join("data/chat_history", f"{base}_history.json")
+
+
+def load_persona_history(persona_label: str):
+    """Load chat history for a persona if it exists."""
+    return load_memory(history_path(persona_label))
+
+
+def save_persona_history(persona_label: str, data):
+    """Persist chat history for a persona."""
+    save_memory(history_path(persona_label), data)

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -1,8 +1,11 @@
-import json
 import os
 import streamlit as st
 from utils import build_system_prompt
 from chat_engine import ChatEngine
+from memory_manager import (
+    load_persona_history,
+    save_persona_history,
+)
 
 
 chat_engine = ChatEngine()
@@ -35,29 +38,31 @@ def chat_page():
     persona_label = st.sidebar.selectbox("\U0001F916 Persona", list(options.keys()))
     persona_path = options[persona_label]
 
-    if st.session_state.get("persona_path") != persona_path:
+    if st.session_state.get("persona_label") != persona_label:
+        st.session_state["persona_label"] = persona_label
         st.session_state["persona_path"] = persona_path
-        st.session_state["messages"] = []
+        st.session_state["messages"] = load_persona_history(persona_label)
 
     system_prompt = build_system_prompt(persona_path)
 
     if st.sidebar.button("\U0001F4BE Save Chat"):
-        with open("chat_history.json", "w") as f:
-            json.dump(st.session_state.get("messages", []), f)
+        save_persona_history(persona_label, st.session_state.get("messages", []))
 
-    if st.sidebar.button("\U0001F4C2 Load Chat") and os.path.exists("chat_history.json"):
-        with open("chat_history.json", "r") as f:
-            st.session_state["messages"] = json.load(f)
-            st.rerun()
+    if st.sidebar.button("\U0001F4C2 Load Chat"):
+        st.session_state["messages"] = load_persona_history(persona_label)
+        st.rerun()
 
     if st.sidebar.button("\U0001F5D1\ufe0f Clear Chat"):
         st.session_state["messages"] = []
+        save_persona_history(persona_label, [])
         st.rerun()
 
     st.session_state.setdefault("messages", [])
 
-    if not any(m["role"] == "system" for m in st.session_state["messages"]):
+    if not st.session_state["messages"] or st.session_state["messages"][0]["role"] != "system":
         st.session_state["messages"].insert(0, {"role": "system", "content": system_prompt})
+    else:
+        st.session_state["messages"][0]["content"] = system_prompt
 
     for msg in st.session_state["messages"]:
         with st.chat_message(msg["role"]):
@@ -85,6 +90,7 @@ def chat_page():
                 full_response = "\u26a0\ufe0f Error occurred while generating response."
 
         st.session_state["messages"].append({"role": "assistant", "content": full_response})
+        save_persona_history(persona_label, st.session_state["messages"])
         st.markdown(
             "<script>window.scrollTo(0,document.body.scrollHeight);</script>",
             unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- maintain separate chat histories per persona
- load persona history automatically when switching personas
- persist persona chat history on user request and after each exchange

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9e3afd78832f8bbf40628b35380d