### PR TITLE
Add Pydantic chat history models

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Make sure LM Studio is running at `http://localhost:1234` with a supported model
 - `character_interface.py`: Trait editor
 - `chat_engine.py`: Wrapper around the OpenAI client
 - `pages/`: Streamlit page modules
-- `persona_model.py`: Pydantic schema
-- `utils.py`: Prompt builder
-- `memory_manager.py`: JSON storage
+- `persona_model.py`: Pydantic schema for character sheets
+- `memory_models.py`: Chat message and history models using Pydantic
+- `utils.py`: Prompt builder that renders validated personas
+- `memory_manager.py`: JSON storage backed by `ChatHistory`
 - `data/personas/default.yaml`: Example persona loaded for system prompts

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -32,12 +32,17 @@ class ChatEngine:
             if content is not None:
                 yield content
 
-    def chat_with_history(self, persona_file, history, user_input, model="gpt-3.5-turbo"):
+    def chat_with_history(self, persona_file: str, history, user_input: str, model: str = "gpt-3.5-turbo"):
         """Send chat completion request using stored history."""
-        messages = [{"role": "system", "content": build_system_prompt(persona_file)}]
-        for entry in history:
-            messages.append({"role": "user", "content": entry["user"]})
-            messages.append({"role": "assistant", "content": entry["ai"]})
+        if hasattr(history, "to_openai"):
+            messages = history.to_openai()
+        else:
+            messages = history
+        system_msg = {"role": "system", "content": build_system_prompt(persona_file)}
+        if not messages or messages[0]["role"] != "system":
+            messages.insert(0, system_msg)
+        else:
+            messages[0]["content"] = system_msg["content"]
         messages.append({"role": "user", "content": user_input})
 
         completion = self.client.chat.completions.create(

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -1,17 +1,23 @@
 import json
 import os
 
+from memory_models import ChatHistory, ChatMessage
 
-def load_memory(filename):
+
+def load_memory(filename: str) -> ChatHistory:
+    """Load chat history from a JSON file."""
     if os.path.exists(filename):
         with open(filename, "r") as f:
-            return json.load(f)
-    return []
+            data = json.load(f)
+            messages = [ChatMessage(**m) for m in data]
+            return ChatHistory(messages=messages)
+    return ChatHistory()
 
 
-def save_memory(filename, data):
+def save_memory(filename: str, history: ChatHistory):
+    """Save chat history to disk."""
     with open(filename, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump([m.model_dump() for m in history.messages], f, indent=2)
 
 
 def history_path(persona_label: str) -> str:
@@ -22,11 +28,11 @@ def history_path(persona_label: str) -> str:
     return os.path.join("data/chat_history", f"{base}_history.json")
 
 
-def load_persona_history(persona_label: str):
+def load_persona_history(persona_label: str) -> ChatHistory:
     """Load chat history for a persona if it exists."""
     return load_memory(history_path(persona_label))
 
 
-def save_persona_history(persona_label: str, data):
+def save_persona_history(persona_label: str, history: ChatHistory):
     """Persist chat history for a persona."""
-    save_memory(history_path(persona_label), data)
+    save_memory(history_path(persona_label), history)

--- a/memory_models.py
+++ b/memory_models.py
@@ -1,0 +1,20 @@
+from typing import List, Literal
+from pydantic import BaseModel
+
+class ChatMessage(BaseModel):
+    """Single message in a conversation."""
+
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+class ChatHistory(BaseModel):
+    """List of chat messages."""
+
+    messages: List[ChatMessage] = []
+
+    def add_message(self, message: ChatMessage):
+        self.messages.append(message)
+
+    def to_openai(self) -> List[dict]:
+        """Return list of messages formatted for OpenAI API."""
+        return [m.model_dump() for m in self.messages]

--- a/utils.py
+++ b/utils.py
@@ -3,14 +3,17 @@
 import json
 import yaml
 from jinja2 import Template
+from persona_model import Persona
 
 
-def load_persona(file_path):
+def load_persona(file_path: str) -> Persona:
     """Load persona data from a YAML or JSON file."""
     with open(file_path, "r") as f:
         if file_path.endswith(".json"):
-            return json.load(f)
-        return yaml.safe_load(f)
+            data = json.load(f)
+        else:
+            data = yaml.safe_load(f)
+    return Persona(**data)
 
 
 SYSTEM_TEMPLATE = Template(
@@ -32,7 +35,7 @@ Stay in character and respond accordingly.
 )
 
 
-def build_system_prompt(file_path):
+def build_system_prompt(file_path: str) -> str:
     """Build a system prompt from a persona file using Jinja."""
-    data = load_persona(file_path)
-    return SYSTEM_TEMPLATE.render(**data)
+    persona = load_persona(file_path)
+    return SYSTEM_TEMPLATE.render(**persona.model_dump())


### PR DESCRIPTION
## Summary
- create `memory_models` with `ChatMessage` and `ChatHistory`
- validate persona files when building system prompts
- manage history via `ChatHistory` in the chat page and memory manager
- adjust `chat_with_history` helper
- document new modules in the README

## Testing
- `python -m py_compile persona_model.py memory_models.py memory_manager.py utils.py chat_engine.py pages/chat.py`

------
https://chatgpt.com/codex/tasks/task_e_684e9ffe2988832f902fd3eb775c020b